### PR TITLE
Fixed bug which was preventing the invariant index from being searche…

### DIFF
--- a/TcbInternetSolutions.Vulcan.Core/Implementation/VulcanClient.cs
+++ b/TcbInternetSolutions.Vulcan.Core/Implementation/VulcanClient.cs
@@ -216,7 +216,7 @@
 
             var indexName = IndexName;
 
-            if (Language.Equals(CultureInfo.InvariantCulture) && includeNeutralLanguage)
+            if (!(Language.Equals(CultureInfo.InvariantCulture)) && includeNeutralLanguage)
             {
                 indexName += "," + VulcanHelper.GetIndexName(VulcanHandler.Index, CultureInfo.InvariantCulture);
             }


### PR DESCRIPTION
Looks like the syntax was updated recently, just forgot to negate the match to Language.Equals(CultureInfo.InvariantCulture) like it was originally .